### PR TITLE
Change rb-inotify-0.9.6 to 0.9.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     parallel (1.6.1)
     rake (10.5.0)
     rb-fsevent (0.9.7)
-    rb-inotify (0.9.6)
+    rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)


### PR DESCRIPTION
Could not find rb-inotify-0.9.6 in any of the sources

"0.9.6 has been yanked."

https://rubygems.org/gems/rb-inotify/versions/0.9.6