### PR TITLE
Fix headers não renderizados no jekyll

### DIFF
--- a/_posts/2015-01-20-a-estrutura-do-svg.md
+++ b/_posts/2015-01-20-a-estrutura-do-svg.md
@@ -42,7 +42,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
 </svg>
 {% endhighlight %}
 
-###O que são essas coisas ali com a tag SVG?
+### O que são essas coisas ali com a tag SVG?
 
 São os `namespaces` do SVG. Eles servem para identificar a versão utilizada no SVG e o namespace padrão dele, assim o browser irá saber qual a melhor forma de renderizar aquele SVG. Isso será bastante importante para nós quando formos manipular o SVG através do Javascript, pois para criar novos elementos e definir atributos, iremos trabalhar no DOM através dos namespaces.
 

--- a/_posts/2015-03-07-estilizando-svg-com-css-parte-1.md
+++ b/_posts/2015-03-07-estilizando-svg-com-css-parte-1.md
@@ -24,7 +24,7 @@ Espero voltar a escrever com mais frequência, até porque tem muita coisa legal
 
 Também pretendo escrever menos e colocar mais exemplos, para facilitar o entendimento de todos e lembre-se, qualquer dúvida é só falar nos comentários, terei o maior prazer em ajudar.
 
-##Introdução
+## Introdução
 
 Como eu sempre escrevo escutando alguma coisa, vou sempre falar o que estou ouvindo nos meus posts, hoje é dia de [Faded Paper Figures](http://www.fadedpaperfigures.com/).
 


### PR DESCRIPTION
Sem espaço entre a marcação de <hX> e o conteúdo o jekyll acaba não
renderizando corretamente o header.